### PR TITLE
dns-free.link is shutting down on July

### DIFF
--- a/resolvers.json
+++ b/resolvers.json
@@ -65,9 +65,6 @@
     "dnsforfamily": {
         "family": "https://dns-doh.dnsforfamily.com/dns-query"
     },
-    "dnsfree": {
-        "family": "https://dns-free.link/family"
-    },
     "dnssb": {
         "freedom": "https://doh.dns.sb/dns-query"
     },


### PR DESCRIPTION
Announced on https://dns-free.link/